### PR TITLE
TASK-32: Initialize SQLite database connection with PRAGMA settings

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -1,0 +1,28 @@
+from typing import Generator
+from sqlalchemy import create_engine, text, event
+from sqlalchemy.orm import sessionmaker, Session
+from .models import SQLModel
+
+# Create engine with SQLite database
+engine = create_engine("sqlite:///politics.db", echo=False)
+
+# Set PRAGMA journal_mode=WAL for better concurrency
+@event.listens_for(engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.close()
+
+# Create sessionmaker
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def get_session() -> Generator[Session, None, None]:
+    """
+    Dependency function that yields a database session.
+    Ensures the session is properly closed after use.
+    """
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/server/main.py
+++ b/server/main.py
@@ -1,12 +1,9 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from sqlmodel import SQLModel, create_engine
+from sqlmodel import SQLModel
 from server.api.routes import router
+from server.database import engine
 from server.models import Politician, VoteRecord, Gift
-
-# Database setup
-DATABASE_URL = "sqlite:///./politics.db"
-engine = create_engine(DATABASE_URL, echo=True)
 
 # Create the FastAPI application
 app = FastAPI(
@@ -18,10 +15,7 @@ app = FastAPI(
 app.include_router(router)
 
 def create_db_and_tables():
-    """Create database tables with WAL mode enabled"""
-    with engine.connect() as conn:
-        conn.exec_driver_sql("PRAGMA journal_mode=WAL;")
-        conn.commit()
+    """Create database tables"""
     SQLModel.metadata.create_all(engine)
 
 @app.on_event("startup")


### PR DESCRIPTION
Implemented SQLite database connection with SQLAlchemy as specified in the task. Set up engine with "sqlite:///politics.db" URL, echo=False, and PRAGMA journal_mode=WAL using event listeners. Added proper session management with SessionLocal and get_session generator. Database initialization is correctly integrated with FastAPI startup events for table creation.